### PR TITLE
add .gitattributes to fix line endings for fteqcc

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+*.h text eol=crlf
+*.qc text eol=crlf
+ 


### PR DESCRIPTION
always use CR LF, since some multi-line macros misbehave under LF